### PR TITLE
feat: add support for send_invite_email field in key generation

### DIFF
--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -42,6 +42,7 @@ resource "litellm_key" "example" {
   guardrails           = ["content_filter", "token_limit"]
   blocked              = false
   tags                 = ["production", "api"]
+  send_invite_email    = true
 }
 ```
 
@@ -49,57 +50,59 @@ resource "litellm_key" "example" {
 
 The following arguments are supported:
 
-* `models` - (Optional) List of models that can be used with this key. This restricts the key to only use the specified models.
+- `models` - (Optional) List of models that can be used with this key. This restricts the key to only use the specified models.
 
-* `max_budget` - (Optional) Maximum budget for this key. This sets an upper limit on the total spend allowed for this key.
+- `max_budget` - (Optional) Maximum budget for this key. This sets an upper limit on the total spend allowed for this key.
 
-* `user_id` - (Optional) User ID associated with this key. This links the key to a specific user in the LiteLLM system.
+- `user_id` - (Optional) User ID associated with this key. This links the key to a specific user in the LiteLLM system.
 
-* `team_id` - (Optional) Team ID associated with this key. This links the key to a specific team in the LiteLLM system.
+- `team_id` - (Optional) Team ID associated with this key. This links the key to a specific team in the LiteLLM system.
 
-* `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key. This helps in controlling concurrent usage.
+- `max_parallel_requests` - (Optional) Maximum number of parallel requests allowed for this key. This helps in controlling concurrent usage.
 
-* `metadata` - (Optional) Metadata associated with this key. This can be used to store additional, custom information about the key.
+- `metadata` - (Optional) Metadata associated with this key. This can be used to store additional, custom information about the key.
 
-* `tpm_limit` - (Optional) Tokens per minute limit for this key. This sets a rate limit based on the number of tokens processed.
+- `tpm_limit` - (Optional) Tokens per minute limit for this key. This sets a rate limit based on the number of tokens processed.
 
-* `rpm_limit` - (Optional) Requests per minute limit for this key. This sets a rate limit based on the number of API calls.
+- `rpm_limit` - (Optional) Requests per minute limit for this key. This sets a rate limit based on the number of API calls.
 
-* `budget_duration` - (Optional) Duration for the budget (e.g., "monthly", "weekly"). This defines the time period for which the `max_budget` applies.
+- `budget_duration` - (Optional) Duration for the budget (e.g., "monthly", "weekly"). This defines the time period for which the `max_budget` applies.
 
-* `allowed_cache_controls` - (Optional) List of allowed cache control directives. This can be used to control caching behavior for requests made with this key.
+- `allowed_cache_controls` - (Optional) List of allowed cache control directives. This can be used to control caching behavior for requests made with this key.
 
-* `soft_budget` - (Optional) Soft budget limit for this key. This can be used to set a warning threshold before reaching the `max_budget`.
+- `soft_budget` - (Optional) Soft budget limit for this key. This can be used to set a warning threshold before reaching the `max_budget`.
 
-* `key_alias` - (Optional) Alias for this key. This provides a human-readable identifier for the key.
+- `key_alias` - (Optional) Alias for this key. This provides a human-readable identifier for the key.
 
-* `duration` - (Optional) Duration for which this key is valid. This sets an expiration time for the key.
+- `duration` - (Optional) Duration for which this key is valid. This sets an expiration time for the key.
 
-* `aliases` - (Optional) Map of model aliases. This allows you to create custom names for models when using this key.
+- `aliases` - (Optional) Map of model aliases. This allows you to create custom names for models when using this key.
 
-* `config` - (Optional) Configuration options for this key. This can be used to set key-specific settings.
+- `config` - (Optional) Configuration options for this key. This can be used to set key-specific settings.
 
-* `permissions` - (Optional) Permissions associated with this key. This defines what actions are allowed with this key.
+- `permissions` - (Optional) Permissions associated with this key. This defines what actions are allowed with this key.
 
-* `model_max_budget` - (Optional) Maximum budget per model. This allows setting different budget limits for each model.
+- `model_max_budget` - (Optional) Maximum budget per model. This allows setting different budget limits for each model.
 
-* `model_rpm_limit` - (Optional) Requests per minute limit per model. This allows setting different RPM limits for each model.
+- `model_rpm_limit` - (Optional) Requests per minute limit per model. This allows setting different RPM limits for each model.
 
-* `model_tpm_limit` - (Optional) Tokens per minute limit per model. This allows setting different TPM limits for each model.
+- `model_tpm_limit` - (Optional) Tokens per minute limit per model. This allows setting different TPM limits for each model.
 
-* `guardrails` - (Optional) List of guardrails applied to this key. This can be used to enforce certain safety or quality checks.
+- `guardrails` - (Optional) List of guardrails applied to this key. This can be used to enforce certain safety or quality checks.
 
-* `blocked` - (Optional) Whether this key is blocked. If set to true, the key will be unable to make any requests.
+- `blocked` - (Optional) Whether this key is blocked. If set to true, the key will be unable to make any requests.
 
-* `tags` - (Optional) List of tags associated with this key. This can be used for organization and filtering of keys.
+- `tags` - (Optional) List of tags associated with this key. This can be used for organization and filtering of keys.
+
+- `send_invite_email` - (Optional) Whether to send an invite email when creating this key. If set to true, an invitation email will be sent to the associated user.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `key` - The generated API key. This is the actual key value that will be used for authentication.
+- `key` - The generated API key. This is the actual key value that will be used for authentication.
 
-* `spend` - The current spend for this key. This reflects the total amount spent using this key so far.
+- `spend` - The current spend for this key. This reflects the total amount spent using this key so far.
 
 ## State Management
 

--- a/litellm/resource_key.go
+++ b/litellm/resource_key.go
@@ -118,6 +118,10 @@ func resourceKey() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"send_invite_email": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"spend": {
 				Type:     schema.TypeFloat,
 				Computed: true,
@@ -207,6 +211,7 @@ func mapResourceDataToKey(d *schema.ResourceData, key *Key) {
 	key.Guardrails = expandStringList(d.Get("guardrails").([]interface{}))
 	key.Blocked = d.Get("blocked").(bool)
 	key.Tags = expandStringList(d.Get("tags").([]interface{}))
+	key.SendInviteEmail = d.Get("send_invite_email").(bool)
 }
 
 func mapKeyToResourceData(d *schema.ResourceData, key *Key) {
@@ -276,6 +281,7 @@ func mapKeyToResourceData(d *schema.ResourceData, key *Key) {
 	if len(key.Tags) > 0 {
 		d.Set("tags", key.Tags)
 	}
+	d.Set("send_invite_email", key.SendInviteEmail)
 	if key.Spend != 0 {
 		d.Set("spend", key.Spend)
 	}

--- a/litellm/resource_key_utils.go
+++ b/litellm/resource_key_utils.go
@@ -76,6 +76,9 @@ func buildKeyData(d *schema.ResourceData) map[string]interface{} {
 	if v, ok := d.GetOkExists("tags"); ok {
 		keyData["tags"] = expandStringList(v.([]interface{}))
 	}
+	if v, ok := d.GetOkExists("send_invite_email"); ok {
+		keyData["send_invite_email"] = v.(bool)
+	}
 
 	return keyData
 }
@@ -106,6 +109,7 @@ func setKeyResourceData(d *schema.ResourceData, key *Key) error {
 		"guardrails":             key.Guardrails,
 		"blocked":                key.Blocked,
 		"tags":                   key.Tags,
+		"send_invite_email":      key.SendInviteEmail,
 	}
 
 	for field, value := range fields {
@@ -176,6 +180,8 @@ func mapToKey(data map[string]interface{}) *Key {
 			key.Blocked = v.(bool)
 		case "tags":
 			key.Tags = v.([]string)
+		case "send_invite_email":
+			key.SendInviteEmail = v.(bool)
 		}
 	}
 	return key

--- a/litellm/types.go
+++ b/litellm/types.go
@@ -106,6 +106,7 @@ type Key struct {
 	Guardrails           []string               `json:"guardrails,omitempty"`
 	Blocked              bool                   `json:"blocked"`
 	Tags                 []string               `json:"tags,omitempty"`
+	SendInviteEmail      bool                   `json:"send_invite_email,omitempty"`
 }
 
 // KeyResponse represents a response from the API containing key information.


### PR DESCRIPTION
- Add SendInviteEmail field to Key struct in types.go
- Add send_invite_email schema field to resource_key.go
- Update mapResourceDataToKey and mapKeyToResourceData functions
- Update buildKeyData, setKeyResourceData, and mapToKey utility functions
- Update documentation to include send_invite_email field

Implements PR #12 changes for supporting email invitations when creating keys.