### PR TITLE
Enable custom headers for LiteLLM requests

### DIFF
--- a/internal/litellm/types.go
+++ b/internal/litellm/types.go
@@ -5,6 +5,7 @@ type ProviderConfig struct {
 	APIBase            string
 	APIKey             string
 	InsecureSkipVerify bool
+	AdditionalHeaders  map[string]string
 }
 
 // ErrorResponse represents an error response from the API.


### PR DESCRIPTION
Adds support for including custom headers in requests to the LiteLLM API.

This allows users to pass additional information, such as custom authentication tokens, to the LiteLLM service.

The provider configuration now accepts an optional `additional_headers` attribute, which is a map of header names to values. These headers are then added to all requests made by the LiteLLM client.